### PR TITLE
Migrate to com.google.android.play:app-update

### DIFF
--- a/update_available_android/android/build.gradle
+++ b/update_available_android/android/build.gradle
@@ -41,7 +41,6 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    // Play Core
-    implementation 'com.google.android.play:core:1.8.0'
-    implementation 'com.google.android.play:core-ktx:1.8.1'
+    implementation 'com.google.android.play:app-update:2.0.1'
+    implementation 'com.google.android.play:app-update-ktx:2.0.1'
 }


### PR DESCRIPTION
Fix error `Duplicate class` when use this package with another packages with google APIs

Please read this: https://developer.android.com/guide/playcore#playcore-migration
And this: https://developer.android.com/guide/playcore/in-app-updates/kotlin-java

Example of errors:

Execution failed for task ':app:checkDebugDuplicateClasses'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckDuplicatesRunnable
   > Duplicate class com.google.android.play.core.appupdate.AppUpdateInfo found in modules jetified-app-update-2.0.1-runtime (com.google.android.play:app-update:2.0.1) and jetified-core-1.8.0-runtime (com.google.android.play:core:1.8.0)
     Duplicate class com.google.android.play.core.appupdate.AppUpdateManager found in modules jetified-app-update-2.0.1-runtime (com.google.android.play:app-update:2.0.1) and jetified-core-1.8.0-runtime (com.google.android.play:core:1.8.0)
