### PR TITLE
Use pubspec_overrides for Dev/CI

### DIFF
--- a/update_available/pubspec_overrides.yaml
+++ b/update_available/pubspec_overrides.yaml
@@ -1,0 +1,7 @@
+dependency_overrides:
+  update_available_android:
+    path: ../update_available_android
+  update_available_ios:
+    path: ../update_available_ios
+  update_available_platform_interface:
+    path: ../update_available_platform_interface

--- a/update_available_android/pubspec_overrides.yaml
+++ b/update_available_android/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  update_available_platform_interface:
+    path: ../update_available_platform_interface

--- a/update_available_ios/pubspec_overrides.yaml
+++ b/update_available_ios/pubspec_overrides.yaml
@@ -1,0 +1,3 @@
+dependency_overrides:
+  update_available_platform_interface:
+    path: ../update_available_platform_interface


### PR DESCRIPTION
For anyone using Dart 2.17+ and for Github actions, this will resolve locally instead of failing builds due to unpublished versions being specified.