### PR TITLE
Bump required min SDK and add CI check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,3 +68,16 @@ jobs:
     - run: flutter pub get
     - run: flutter format -o show -l 200 --set-exit-if-changed .
     - run: flutter analyze --no-pub --no-congratulate
+  checks_min_sdk_on_update_available:
+    name: Checks Min SDK on update_available
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: update_available
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          version: '2.8.0'
+          channel: 'stable'
+      - run: flutter pub get

--- a/update_available/example/pubspec.yaml
+++ b/update_available/example/pubspec.yaml
@@ -5,8 +5,8 @@ repository: https://github.com/mateusfccp/update_available/tree/master/update_av
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.15.0 <3.0.0"
+  flutter: ">=2.8.0"
 
 dependencies:
   update_available:

--- a/update_available/pubspec.yaml
+++ b/update_available/pubspec.yaml
@@ -4,8 +4,8 @@ version: 2.2.0-dev.1
 repository: https://github.com/mateusfccp/update_available/tree/master/update_available
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.15.0 <3.0.0"
+  flutter: ">=2.8.0"
 
 dependencies:
   flutter:

--- a/update_available_android/pubspec.yaml
+++ b/update_available_android/pubspec.yaml
@@ -4,8 +4,8 @@ version: 2.2.0-dev.1
 repository: https://github.com/mateusfccp/update_available/tree/master/update_available_android
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.15.0 <3.0.0"
+  flutter: ">=2.8.0"
 
 dependencies:
   flutter:

--- a/update_available_ios/pubspec.yaml
+++ b/update_available_ios/pubspec.yaml
@@ -4,8 +4,8 @@ version: 2.2.0-dev.1
 repository: https://github.com/mateusfccp/update_available/tree/master/update_available_ios
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.0.0"
+  sdk: ">=2.15.0 <3.0.0"
+  flutter: ">=2.8.0"
 
 dependencies:
   flutter:

--- a/update_available_platform_interface/pubspec.yaml
+++ b/update_available_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.2.0-dev.1
 repository: https://github.com/mateusfccp/update_available/tree/master/update_available_platform_interface
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   meta: ^1.7.0


### PR DESCRIPTION
* required due to `meta: ^1.7.0` dependency
* required due to invalid plugin registrations prior to Flutter 2.8.0