### PR TITLE
Bump http version range

### DIFF
--- a/update_available_ios/CHANGELOG.md
+++ b/update_available_ios/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.0
 
 - Update `package_info_plus` version range
+- Update `http` version range
 
 ## 2.2.0
 

--- a/update_available_ios/pubspec.yaml
+++ b/update_available_ios/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  http: ^0.13.4
+  http: ">=0.13.4 <2.0.0"
   meta: ^1.7.0
   package_info_plus: ">=3.0.1 <5.0.0"
   pub_semver: ^2.1.1


### PR DESCRIPTION
This change supports the newly released `http: 1.x` version range.