### PR TITLE
Bump package_info_plus constraints to include 8.0.0

### DIFF
--- a/update_available_ios/CHANGELOG.md
+++ b/update_available_ios/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.2
 
-- Supported `package_info_plus: '>=4.0.2 <8.0.0'`
+- Supported `package_info_plus: '>=4.0.2 <9.0.0'`
 
 ## 3.0.1
 

--- a/update_available_ios/pubspec.yaml
+++ b/update_available_ios/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.9.1
-  package_info_plus: ">=4.0.2 <8.0.0"
+  package_info_plus: ">=4.0.2 <9.0.0"
   pub_semver: ^2.1.4
   update_available_platform_interface: ^4.0.1
 


### PR DESCRIPTION
There is a breaking change for Android, does not affect the iOS implementation.
See https://pub.dev/packages/package_info_plus/changelog#800