### PR TITLE
iOS version: force itunes to unvalidate its cache

### DIFF
--- a/update_available_ios/CHANGELOG.md
+++ b/update_available_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Bust iTunes cache when fetching the published plugin version (see #45)
+
 ## 3.0.2
 
 - Support `package_info_plus: '>=4.0.2 <9.0.0'`

--- a/update_available_ios/lib/adapters/get_ios_package_version_impl.dart
+++ b/update_available_ios/lib/adapters/get_ios_package_version_impl.dart
@@ -12,10 +12,12 @@ GetIOSPackageVersion httpGetIOSPackageVersion() {
   return (String bundleId, {String? iosAppStoreRegion}) async {
     final Uri uri;
 
+    // Busting iTunes CDN cache
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
     if (iosAppStoreRegion == null) {
-      uri = Uri.parse('$_itunesURL/lookup?bundleId=$bundleId');
+      uri = Uri.parse('$_itunesURL/lookup?bundleId=$bundleId&_=$timestamp');
     } else {
-      uri = Uri.parse('$_itunesURL/$iosAppStoreRegion/lookup?bundleId=$bundleId');
+      uri = Uri.parse('$_itunesURL/$iosAppStoreRegion/lookup?bundleId=$bundleId&_=$timestamp');
     }
 
     final client = HttpClient();


### PR DESCRIPTION
Fixes #44 

Forces Itunes to invalidate its cache and prevent sending outdated version.

#### First approach

I tried using `no-cache` headers

```dart
// Prevent server-side cache
request.headers.add(HttpHeaders.cacheControlHeader, "no-cache, no-store, must-revalidate");
```

However iTunes CDN does not seem to accept them.

#### Second approach

I added a random string in the URL. It feels a bit hacky, so I am not sure if you want to use this PR. Up to you.