### PR TITLE
upgrade tooling and SDK versions

### DIFF
--- a/update_available/CHANGELOG.md
+++ b/update_available/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 - Bump version to 3.3.0 across packages
 - Update Kotlin to 2.4.0 and Gradle to 9.5.1
-- Update Android Gradle Plugin to 9.2.0 and `compileSdk` to 36
+- Update Android Gradle Plugin to 9.1.1 and `compileSdk` to 36
 - Set Java compatibility and `jvmTarget` to version 17
 - Replace JCenter with MavenCentral in repository configurations
 

--- a/update_available/CHANGELOG.md
+++ b/update_available/CHANGELOG.md
@@ -1,3 +1,14 @@
+
+## 3.3.0
+
+- Upgrade tooling and SDK versions for 3.3.0
+
+- Bump version to 3.3.0 across packages
+- Update Kotlin to 2.4.0 and Gradle to 9.5.1
+- Update Android Gradle Plugin to 9.2.0 and `compileSdk` to 36
+- Set Java compatibility and `jvmTarget` to version 17
+- Replace JCenter with MavenCentral in repository configurations
+
 ## 3.2.1
 
 - Relax dependencies constraints (@akshaynexus)

--- a/update_available/example/android/app/build.gradle
+++ b/update_available/example/android/app/build.gradle
@@ -11,12 +11,12 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/update_available/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/update_available/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-all.zip

--- a/update_available/example/android/settings.gradle
+++ b/update_available/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "com.android.application" version '9.2.0' apply false
+    id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 
 include ":app"

--- a/update_available/example/android/settings.gradle
+++ b/update_available/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.9.1' apply false
+    id "com.android.application" version '9.1.1' apply false
     id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 

--- a/update_available/example/android/settings.gradle
+++ b/update_available/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '9.2.0' apply false
+    id "com.android.application" version '9.2.1' apply false
     id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 

--- a/update_available/example/android/settings.gradle
+++ b/update_available/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '9.2.1' apply false
+    id "com.android.application" version '8.9.1' apply false
     id "org.jetbrains.kotlin.android" version "2.4.0" apply false
 }
 

--- a/update_available/pubspec.yaml
+++ b/update_available/pubspec.yaml
@@ -1,6 +1,6 @@
 name: update_available
 description: Know if there's any update for your Flutter app, based on published versions.
-version: 3.2.1
+version: 3.3.0
 repository: https://github.com/mateusfccp/update_available/tree/master/update_available
 
 environment:
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  update_available_android: ^3.2.0
+  update_available_android: ^3.3.0
   update_available_ios: ^3.1.1
   update_available_platform_interface: ^4.1.1
 

--- a/update_available_android/CHANGELOG.md
+++ b/update_available_android/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bump version to 3.3.0 across packages
 - Update Kotlin to 2.4.0 and Gradle to 9.5.1
-- Update Android Gradle Plugin to 9.2.0 and `compileSdk` to 36
+- Update Android Gradle Plugin to 9.1.1 and `compileSdk` to 36
 - Set Java compatibility and `jvmTarget` to version 17
 - Replace JCenter with MavenCentral in repository configurations
 

--- a/update_available_android/CHANGELOG.md
+++ b/update_available_android/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.3.0
+
+- Upgrade tooling and SDK versions for 3.3.0
+
+- Bump version to 3.3.0 across packages
+- Update Kotlin to 2.4.0 and Gradle to 9.5.1
+- Update Android Gradle Plugin to 9.2.0 and `compileSdk` to 36
+- Set Java compatibility and `jvmTarget` to version 17
+- Replace JCenter with MavenCentral in repository configurations
+
 ## 3.2.0+1
 
 - Update lint dependencies

--- a/update_available_android/android/build.gradle
+++ b/update_available_android/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:9.2.0'")
+        classpath("com.android.tools.build:gradle:9.2.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }

--- a/update_available_android/android/build.gradle
+++ b/update_available_android/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:9.2.1")
+        classpath("com.android.tools.build:gradle:8.9.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }

--- a/update_available_android/android/build.gradle
+++ b/update_available_android/android/build.gradle
@@ -2,38 +2,38 @@ group 'me.mateusfccp.update_available_android'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '2.4.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath("com.android.tools.build:gradle:9.2.0'")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }
 
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-
-kotlin {
-    jvmToolchain(17)
-}
+apply plugin: "com.android.library"
+apply plugin: "kotlin-android"
 
 android {
-    compileSdkVersion 34
+    compileSdk = 36
 
     compileOptions {
-        sourceCompatibility = 17
-        targetCompatibility = 17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     // Conditional for compatibility with AGP <4.2.

--- a/update_available_android/android/build.gradle
+++ b/update_available_android/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.9.1")
+        classpath("com.android.tools.build:gradle:9.1.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
     }
 }

--- a/update_available_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/update_available_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-all.zip

--- a/update_available_android/pubspec.yaml
+++ b/update_available_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: update_available_android
 description: Android platform implementation of update_available
-version: 3.2.0+1
+version: 3.3.0
 repository: https://github.com/mateusfccp/update_available/tree/master/update_available_android
 
 environment:


### PR DESCRIPTION
- Upgrade tooling and SDK versions for 3.3.0

- Bump version to 3.3.0 across packages
- Update Kotlin to 2.4.0 and Gradle to 9.5.1
- Update Android Gradle Plugin to 9.1.1 and `compileSdk` to 36
- Set Java compatibility and `jvmTarget` to version 17
- Replace JCenter with MavenCentral in repository configurations